### PR TITLE
options.PouchDB

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,19 +15,12 @@ using a PouchDB instance for persistence.
 ```js
 var AccountApi = require('@hoodie/account-server-api')
 var PouchDB = require('pouchdb')
+  .plugin(require('pouchdb-users'))
 
-PouchDB.plugin(require('pouchdb-users'))
-
-var db = new PouchDB('http://localhost:5984/_users')
-
-db.installUsersBehavior().then(function () {
-  var api = new AccountApi({
-    db: db,
-    secret: 'secret123'
-  })
-
-  api.accounts.findAll().then(logAccountStats)
-  api.accounts.on('change', logAccountChange)
+var api = new AccountApi({
+  PouchDB: PouchDB,
+  usersDb: 'my-users-db',
+  secret: 'secret123'
 })
 ```
 
@@ -82,12 +75,10 @@ new AccountApi(options)
     </tr>
   </thead>
   <tr>
-    <th align="left"><code>options.db</code></th>
+    <th align="left"><code>options.PouchDB</code></th>
     <td>Object</td>
     <td>
-      PouchDB instance with
-      <a href="https://github.com/hoodiehq/pouchdb-users">pouchdb-users</a>
-      plugin
+      <a href="https://pouchdb.com/">PouchDB</a> constructor
     </td>
     <td>Yes</td>
   </tr>
@@ -98,6 +89,14 @@ new AccountApi(options)
       Server secret, like CouchDB’s <code>couch_httpd_auth.secret</code>
     </td>
     <td>Yes</td>
+  </tr>
+  <tr>
+    <th align="left"><code>options.usersDb</code></th>
+    <td>String</td>
+    <td>
+      Defaults to <code>_users</code>
+    </td>
+    <td>No</td>
   </tr>
 </table>
 

--- a/index.js
+++ b/index.js
@@ -18,9 +18,10 @@ var accountsOn = require('./lib/accounts/on')
 var startListeningToAccountChanges = require('./lib/utils/start-listening-to-account-changes')
 
 function accountApi (options) {
+  options.PouchDB.plugin(require('pouchdb-users'))
   var accountsEmitter = new EventEmitter()
   var state = {
-    db: options.db,
+    db: new options.PouchDB(options.usersDb || '_users'),
     secret: options.secret,
     accountsEmitter: accountsEmitter
   }

--- a/lib/setup.js
+++ b/lib/setup.js
@@ -10,4 +10,8 @@ function setup (state) {
       throw error
     }
   })
+
+  .then(function () {
+    return state.db.installUsersBehavior()
+  })
 }

--- a/package.json
+++ b/package.json
@@ -36,7 +36,6 @@
     "base64url": "^2.0.0",
     "coveralls": "^2.11.14",
     "nyc": "^8.3.1",
-    "pouchdb-users": "^1.0.3",
     "semantic-release": "^6.3.1",
     "standard": "^8.4.0",
     "tap": "^7.1.2"
@@ -51,6 +50,7 @@
     "pouchdb-core": "^6.0.6",
     "pouchdb-errors": "6.0.6",
     "pouchdb-mapreduce": "^6.0.6",
+    "pouchdb-users": "^1.0.3",
     "uuid": "^2.0.3"
   }
 }

--- a/test/integration/accounts-test.js
+++ b/test/integration/accounts-test.js
@@ -1,57 +1,47 @@
 var PouchDB = require('pouchdb-core')
   .plugin(require('pouchdb-mapreduce'))
   .plugin(require('pouchdb-adapter-memory'))
-  .plugin(require('pouchdb-users'))
 var test = require('tap').test
 
 var getApi = require('../../')
 
-PouchDB.plugin(require('pouchdb-users'))
-
 test('walkthrough', function (t) {
   t.plan(10)
 
-  var usersDb = new PouchDB('users')
-
-  usersDb.installUsersBehavior()
-
-  .then(function () {
-    var api = getApi({
-      db: usersDb,
-      secret: 'secret'
-    })
-
-    api.accounts.on('change', function (eventName) {
-      t.pass('change event emitted') // gets emitted twice
-    })
-    api.accounts.on('add', function (account) {
-      t.pass('add event emitted')
-      t.is(account.username, 'foo', '"add" event emmited with account.username')
-      t.is(account.id, 'user123', '"add" event emmited with account.id')
-    })
-    api.accounts.on('remove', function (account) {
-      t.pass('remove event emitted')
-      t.is(account.username, 'foo', '"remove" event emmited with account.username')
-      t.is(account.id, 'user123', '"remove" event emmited with account.id')
-    })
-
-    api.accounts.add({
-      id: 'user123',
-      username: 'foo',
-      password: 'foosecret'
-    })
-
-    .then(function (account) {
-      t.pass('creates account')
-
-      return api.accounts.remove(account.id)
-    })
-
-    .then(function (account) {
-      t.pass('deletes account')
-    })
-
-    .catch(t.error)
+  var api = getApi({
+    PouchDB: PouchDB,
+    secret: 'secret'
   })
+
+  api.accounts.on('change', function (eventName) {
+    t.pass('change event emitted') // gets emitted twice
+  })
+  api.accounts.on('add', function (account) {
+    t.pass('add event emitted')
+    t.is(account.username, 'foo', '"add" event emmited with account.username')
+    t.is(account.id, 'user123', '"add" event emmited with account.id')
+  })
+  api.accounts.on('remove', function (account) {
+    t.pass('remove event emitted')
+    t.is(account.username, 'foo', '"remove" event emmited with account.username')
+    t.is(account.id, 'user123', '"remove" event emmited with account.id')
+  })
+
+  api.accounts.add({
+    id: 'user123',
+    username: 'foo',
+    password: 'foosecret'
+  })
+
+  .then(function (account) {
+    t.pass('creates account')
+
+    return api.accounts.remove(account.id)
+  })
+
+  .then(function (account) {
+    t.pass('deletes account')
+  })
+
   .catch(t.error)
 })


### PR DESCRIPTION
closes https://github.com/hoodiehq/camp/issues/52

Before, `options.db` had to be passed to the Api constructor, pre-initialised with `"pouchdb-users"`:
                   
```js                    
var AccountApi = require("@hoodie/account-server-api")
var PouchDB = require("pouchdb")

PouchDB.plugin(require("pouchdb-users"))

var db = new PouchDB("http://localhost:5984/_users")

db.installUsersBehavior().then(function () {
  var api = new AccountApi({
    db: db,
    secret: "secret123"
  })

  api.accounts.findAll().then(logAccountStats)
  api.accounts.on("change", logAccountChange)
})
```

Now, `options.PouchDB` is enough. Optionally `options.usersDb` for a custom users db name can be passed (it defaults to `_users`):

```js
var AccountApi = require("@hoodie/account-server-api")
var PouchDB = require("pouchdb")
  .plugin(require("pouchdb-users"))

var api = new AccountApi({
  PouchDB: PouchDB,
  usersDb: "my-users-db",
  secret: "secret123"
})
```