### PR TITLE
test: sessions.remove('sessionid')

### DIFF
--- a/lib/sessions/remove.js
+++ b/lib/sessions/remove.js
@@ -5,10 +5,4 @@ internals.findSession = require('./find')
 
 function removeSession (state, id, options) {
   return internals.findSession(state, id, options)
-
-  .then(function (session) {
-    if (options.include) {
-      return session
-    }
-  })
 }

--- a/test/unit/sessions/remove-test.js
+++ b/test/unit/sessions/remove-test.js
@@ -23,7 +23,7 @@ test('removeSession', function (group) {
   })
 
   // prepared for https://github.com/hoodiehq/camp/issues/58
-  group.test('session found', {skip: true}, function (t) {
+  group.test('session found', {skip: false}, function (t) {
     t.plan(2)
 
     simple.mock(internals, 'findSession').resolveWith({


### PR DESCRIPTION
Removed unnecessary code in remove.js that was sometimes causing session to be not returned.

closes hoodiehq/camp#58

===
paired with @jimthoburn @fullstackla ⚡️ 