### PR TITLE
Remove deprecation warning on node 6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,7 @@ notifications:
   email: false
 node_js:
   - '4'
+  - '6'
 before_install:
   - npm i -g npm@^2.0.0
 before_script:

--- a/lib/utils/validate-password.js
+++ b/lib/utils/validate-password.js
@@ -3,7 +3,7 @@ module.exports = validatePassword
 var crypto = require('crypto')
 
 function validatePassword (password, salt, iterations, derivedKey, callback) {
-  crypto.pbkdf2(password, salt, iterations, 20, function (error, derivedKeyCheck) {
+  crypto.pbkdf2(password, salt, iterations, 20, 'sha1', function (error, derivedKeyCheck) {
     if (error) {
       return callback(error)
     }


### PR DESCRIPTION
If you run hoodie-account-server-api on node 6, it'll print out a deprecation message like this:

`DeprecationWarning: crypto.pbkdf2 without specifying a digest is deprecated. Please specify a digest`

This is, because in Node 4.x the [digest was optional and defaulted to 'sha1'](https://nodejs.org/dist/latest-v4.x/docs/api/crypto.html#crypto_crypto_pbkdf2_password_salt_iterations_keylen_digest_callback), but in [Node 6 it's no longer optional](https://nodejs.org/dist/latest-v6.x/docs/api/crypto.html#crypto_crypto_pbkdf2_password_salt_iterations_keylen_digest_callback) (although still supported).

