### PR TITLE
Usernames with capital letters fail to authenticate

### DIFF
--- a/lib/accounts/add.js
+++ b/lib/accounts/add.js
@@ -16,13 +16,28 @@ function addAccount (state, properties, options) {
     return Promise.reject(errors.USERNAME_EMPTY)
   }
 
-  var accountKey = 'org.couchdb.user:' + properties.username
+  var lowercaseUsername = properties.username.toLowerCase()
+
+  /*
+    lowercaseUsername value will be used to create the accountKey.
+
+    We require this since the user lookup is based on this key and
+    @hoodie/account-server looks up for the user using the lowercase
+    version of the accountKey.
+    See https://github.com/hoodiehq/hoodie-account-server/issues/271
+
+    We also need to change the name parameter inside the doc to use
+    the lowercase version since pouchdb-users requires the doc ID to
+    be of the form 'org.couchdb.user:<name>'
+  */
+
+  var accountKey = 'org.couchdb.user:' + lowercaseUsername
   var accountId = properties.id || uuid.v4()
 
   var doc = {
     _id: accountKey,
     type: 'user',
-    name: properties.username,
+    name: lowercaseUsername,
     password: properties.password,
     createdAt: properties.createdAt,
     signedUpAt: properties.signedUpAt,
@@ -42,6 +57,7 @@ function addAccount (state, properties, options) {
   })
 
   .catch(function (error) {
+    console.log(error)
     if (error.status === 409) {
       throw errors.USERNAME_EXISTS
     }

--- a/lib/accounts/add.js
+++ b/lib/accounts/add.js
@@ -57,7 +57,6 @@ function addAccount (state, properties, options) {
   })
 
   .catch(function (error) {
-    console.log(error)
     if (error.status === 409) {
       throw errors.USERNAME_EXISTS
     }

--- a/test/unit/accounts/add-test.js
+++ b/test/unit/accounts/add-test.js
@@ -109,6 +109,28 @@ test('addAccount', function (group) {
     })
   })
 
+  group.test('with username containing uppercase letters', function (t) {
+    t.plan(1)
+
+    var state = {
+      cache: {
+        set: simple.stub().resolveWith({})
+      },
+      setupPromise: Promise.resolve()
+    }
+
+    addAccount(state, {
+      username: 'userWithCAPS'
+    })
+
+    .then(function () {
+      var doc = state.cache.set.lastCall.arg
+      t.deepEqual(doc.name, 'userwithcaps')
+    })
+
+    .catch(t.catch)
+  })
+
   group.test('with other error', function (t) {
     t.plan(3)
 


### PR DESCRIPTION
Fixes https://github.com/hoodiehq/hoodie-account-server/issues/271 by storing the lowercase version of name and accountKey.